### PR TITLE
Support to Destroy elements from Container

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -68,11 +68,49 @@ class Container extends ArrayObject
         return $this;
     }
 
+    /**
+     * Destroys an element from the Container with the given path
+     *
+     * @param $path The path of the key to destroy
+     * @return \Container
+     */
+    public function offsetUnset($path)
+    {
+        if ($this->has($path)) {
+            $this->exchangeArray(
+                self::recursive_diff_key(
+                    $this->getArrayCopy(),
+                    $this->buildTree($path, null)
+                )
+            );
+        }
+
+        return $this;
+    }
+
     public function reset()
     {
         $this->exchangeArray([]);
 
         return $this;
+    }
+
+    private function recursive_diff_key(array $array1, array $array2)
+    {
+        $diff = array_diff_key($array1, $array2);
+        $to_check = array_intersect_key($array1, $array2);
+
+        foreach ($to_check as $k => $v) {
+            if (is_array($array1[$k]) && is_array($array2[$k])) {
+                $keep = self::recursive_diff_key($array1[$k], $array2[$k]);
+
+                if ($keep) {
+                    $diff[$k] = $keep;
+                }
+            }
+        }
+
+        return $diff;
     }
 
     private function buildTree($path, $value = null)

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -143,6 +143,23 @@ class ContainerTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($dot->has('sender.login'));
     }
 
+    public function testOffsetUnset()
+    {
+        $dot = Container::create($this->data);
+
+        $this->assertTrue($dot->has('issue.labels.0'));
+        $this->assertArrayHasKey('color', $dot->get('issue.labels.0'));
+
+        $dot->offsetUnset('issue.labels.0.color');
+
+        $this->assertArrayNotHasKey('color', $dot->get('issue.labels.0'));
+
+        $this->assertTrue($dot->has('issue.labels.0.url'));
+        $this->assertTrue($dot->has('issue.labels.0.name'));
+        $this->assertArrayHasKey('url', $dot->get('issue.labels.0'));
+        $this->assertArrayHasKey('name', $dot->get('issue.labels.0'));
+    }
+
     public function testReset()
     {
         $dot = Container::create($this->data);


### PR DESCRIPTION
What does this Pull Request Do?
-------------------------------
- Added a method to get the diff between multidimensional arrays using keys
- Overrided OffsetUnset to destroy elements with the given path
- Added UnitTests for OffsetUnset method

How should this be manually tested?
-----------------------------------
`phpunit` should be enough. CS Fixer was run also.